### PR TITLE
Remove unused GestionPociones field

### DIFF
--- a/core/src/main/java/com/proyectofinal/DungeonScreen.java
+++ b/core/src/main/java/com/proyectofinal/DungeonScreen.java
@@ -26,7 +26,6 @@ public class DungeonScreen extends PantallaBase {
     private static final int spawnTileY = MAP_HEIGHT / 2;  // = 50
     private final long seed = System.currentTimeMillis();
 
-    private GestionPociones gestionPociones;
     private PlayerHUD playerHUD;
     private SpriteBatch batch;
     private BitmapFont font;
@@ -507,10 +506,6 @@ public class DungeonScreen extends PantallaBase {
                 }
             }
 
-            // Liberar recursos del sistema de pociones
-            if (gestionPociones != null) {
-                gestionPociones.dispose();
-            }
             // Liberar recursos del HUD
             if (playerHUD != null) {
                 playerHUD.dispose();


### PR DESCRIPTION
## Summary
- remove the unused `GestionPociones` field from `DungeonScreen`
- drop leftover dispose code

## Testing
- `./gradlew test --console=plain` *(fails: unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68634b056fd0832690d08ff884b6c3da